### PR TITLE
Allow defining arbitrary field as PK field. Rename PrimaryKeyField -> IdField

### DIFF
--- a/nefertari_mongodb/__init__.py
+++ b/nefertari_mongodb/__init__.py
@@ -29,7 +29,7 @@ from .fields import (
     UnicodeField,
     UnicodeTextField,
     Relationship,
-    PrimaryKeyField,
+    IdField,
     ForeignKeyField,
 
     ListField,

--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -443,7 +443,7 @@ class BaseDocument(BaseMixin, mongo.Document):
         """
         for name, field in self._fields.items():
             if hasattr(field, 'apply_processors'):
-                value = self._data.get(name)
+                value = getattr(self, name)
                 value = field.apply_processors(value)
                 setattr(self, name, value)
 

--- a/nefertari_mongodb/fields.py
+++ b/nefertari_mongodb/fields.py
@@ -308,14 +308,15 @@ class DictField(ProcessableMixin, BaseFieldMixin, fields.DictField):
     _valid_kwargs = ('basecls', 'field')
 
 
-class PrimaryKeyField(ProcessableMixin, BaseFieldMixin, fields.ObjectIdField):
-    """ Just a subclass of ObjectIdField. """
+class IdField(ProcessableMixin, BaseFieldMixin, fields.ObjectIdField):
+    """ Just a subclass of ObjectIdField that must be used for fields
+    that represent database-specific 'id' field.
+    """
     _valid_kwargs = ('primary_key',)
 
     def __init__(self, *args, **kwargs):
-        # kwargs['primary_key'] = True
-        kwargs['primary_key'] = False
-        super(PrimaryKeyField, self).__init__(*args, **kwargs)
+        kwargs.pop('primary_key', None)
+        super(IdField, self).__init__(*args, **kwargs)
 
 
 class ForeignKeyField(BaseFieldMixin, fields.StringField):


### PR DESCRIPTION
Also fixes bug when field value was not available at the moment of applying processors sometimes.