### PR TITLE
Fix bugs with backref updates

### DIFF
--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -604,7 +604,6 @@ class BaseDocument(BaseMixin, mongo.Document):
         """
         kw['force_insert'] = self._created
 
-        sync_backref = kw.pop('sync_backref', True)
         self._refresh_index = kw.pop('refresh_index', None)
         self._bump_version()
         try:
@@ -619,8 +618,7 @@ class BaseDocument(BaseMixin, mongo.Document):
                     self.__class__.__name__),
                 extra={'data': e})
         else:
-            if sync_backref:
-                self.run_backref_hooks()
+            self.run_backref_hooks()
             self._backref_hooks = ()
             return self
 

--- a/nefertari_mongodb/fields.py
+++ b/nefertari_mongodb/fields.py
@@ -420,16 +420,13 @@ class ReferenceField(BaseFieldMixin, fields.ReferenceField):
         super(ReferenceField, self).__init__(*args, **kwargs)
 
     def _register_deletion_hook(self, old_object, instance):
-        """ Register a backref hook to delete the `instance` from the `old_object`'s
-        field to which the `instance` was related beforehand by the backref.
+        """ Register a backref hook to delete the `instance` from the
+        `old_object`'s field to which the `instance` was related before
+        by the backref.
 
         `instance` is either deleted from the `old_object` field's collection
         or `old_object`'s field, responsible for relationship is set to None.
         This depends on type of the field at `old_object`.
-
-        `old_object.update` is run with `sync_backref=False` because
-        original relationship side is already updated and it is the one
-        who calls the hook. This also prevents recursion in One2One.
 
         `instance` is not actually used in hook - up-to-date value of
         `instance` is passed to hook when it is run.
@@ -440,12 +437,15 @@ class ReferenceField(BaseFieldMixin, fields.ReferenceField):
             if field_value:
                 field_object = old_obj._fields[field_name]
                 if isinstance(field_object, ListField):
-                    field_value = field_value or []
-                    if document in field_value:
-                        field_value.remove(document)
+                    new_value = list(field_value or [])
+                    if document in new_value:
+                        new_value.remove(document)
                 else:
-                    field_value = None
-                old_obj.update({field_name: field_value}, sync_backref=False)
+                    new_value = (None if field_value == document
+                                 else field_value)
+
+                if new_value != field_value:
+                    old_obj.update({field_name: new_value})
 
         old_object_hook = partial(
             _delete_from_old,
@@ -454,16 +454,12 @@ class ReferenceField(BaseFieldMixin, fields.ReferenceField):
         instance._backref_hooks += (old_object_hook,)
 
     def _register_addition_hook(self, new_object, instance):
-        """ Register backref hook to add `instance` to the `old_object`s
+        """ Register backref hook to add `instance` to the `new_object`s
         field to which `instance` became related by the backref.
 
-        `instance` is either added to `old_object` field's collection or
-        `old_object`s field, responsible for relationship is set to `instance`.
-        This depends on type of the field at `old_object`.
-
-        `new_object.update` is run with `sync_backref=False` because
-        original relationship side is already updated and it is the one
-        who calls the hook. This also prevents recursion in One2One.
+        `instance` is either added to `new_object` field's collection or
+        `new_object`s field, responsible for relationship is set to `instance`.
+        This depends on type of the field at `new_object`.
 
         `instance` is not actually used in hook - up-to-date value of
         `instance` is passed to hook when it is run.
@@ -473,12 +469,15 @@ class ReferenceField(BaseFieldMixin, fields.ReferenceField):
             field_value = getattr(new_obj, field_name, None)
             field_object = new_obj._fields[field_name]
             if isinstance(field_object, ListField):
-                field_value = field_value or []
-                if document not in field_value:
-                    field_value.append(document)
+                new_value = list(field_value or [])
+                if document not in new_value:
+                    new_value.append(document)
             else:
-                field_value = document
-            new_obj.update({field_name: field_value}, sync_backref=False)
+                new_value = (document if field_value != document
+                             else field_value)
+
+            if new_value != field_value:
+                new_obj.update({field_name: new_value})
 
         new_object_hook = partial(
             _add_to_new,
@@ -505,7 +504,6 @@ class ReferenceField(BaseFieldMixin, fields.ReferenceField):
         old_object = getattr(instance, self.name)
         new_object = value
         super_set(instance, value)
-
         # The same object is being set - no changes needed
         if new_object == old_object:
             return


### PR DESCRIPTION
Get rid of backref_sync option for save.
ReferenceField backref update methods now make sure new value
is not equal to the old one before update.
One2One backrefs updates now also check make sure new value
is not equal to old value.