### PR TITLE
Add support for field onupdate. Remove updated_at field definition

### DIFF
--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-from datetime import datetime
 
 import six
 import mongoengine as mongo
@@ -18,7 +17,7 @@ from .fields import (
     TextField, UnicodeField, UnicodeTextField,
     IdField, BooleanField, BinaryField, DecimalField, FloatField,
     BigIntegerField, SmallIntegerField, IntervalField, DateField,
-    TimeField
+    TimeField, BaseFieldMixin
 )
 
 
@@ -742,6 +741,12 @@ class BaseDocument(six.with_metaclass(DocumentMetaclass,
         self.time_field will be equal to '11/22/2000' here.
         """
         self.apply_processors(self._fields_to_process, after=True)
+
+    def clean(self):
+        """ Clean fields which are instances of BaseFieldMixin """
+        for field_name, field_obj in self._fields.items():
+            if isinstance(field_obj, BaseFieldMixin):
+                field_obj.clean(self)
 
 
 class ESBaseDocument(six.with_metaclass(ESMetaclass, BaseDocument)):

--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -594,7 +594,6 @@ class BaseMixin(object):
 
 class BaseDocument(six.with_metaclass(DocumentMetaclass,
                                       BaseMixin, mongo.Document)):
-    updated_at = DateTimeField()
     _version = IntegerField(default=0)
 
     meta = {
@@ -628,7 +627,6 @@ class BaseDocument(six.with_metaclass(DocumentMetaclass,
 
     def _bump_version(self):
         if self._is_modified():
-            self.updated_at = datetime.utcnow()
             self._version += 1
 
     def save(self, *arg, **kw):

--- a/nefertari_mongodb/fields.py
+++ b/nefertari_mongodb/fields.py
@@ -1,6 +1,5 @@
 import datetime
 import pickle
-from inspect import getargspec
 from functools import partial
 
 import six
@@ -80,33 +79,14 @@ class ProcessableMixin(object):
         self.after_validation = kwargs.pop('after_validation', ())
         super(ProcessableMixin, self).__init__(*args, **kwargs)
 
-    def _get_processor_kwargs(self, proc, kwargs):
-        """ Get values for arguments expected by processor.
-
-        :kwargs: are filtered by checking which :kwargs: keys are
-        defined as arguments of :proc: callable.
-
-        Arguments:
-            :proc: Processor function.
-            :kwargs: Dict containing full set of values that that are
-                desired to be passed to processor.
-        """
-        defined_args = getargspec(proc).args
-        return {k: v for k, v in kwargs.items() if k in defined_args}
-
-    def apply_processors(self, instance, new_value,
-                         before=False, after=False):
+    def apply_processors(self, instance, new_value, before=False, after=False):
         processors = []
         if before:
             processors += list(self.before_validation)
         if after:
             processors += list(self.after_validation)
         for proc in processors:
-            proc_kwargs = self._get_processor_kwargs(proc, kwargs={
-                'instance': instance,
-                'new_value': new_value,
-            })
-            new_value = proc(**proc_kwargs)
+            new_value = proc(instance=instance, new_value=new_value)
         return new_value
 
 

--- a/nefertari_mongodb/fields.py
+++ b/nefertari_mongodb/fields.py
@@ -1,5 +1,6 @@
 import datetime
 import pickle
+from inspect import getargspec
 from functools import partial
 
 import six
@@ -79,14 +80,33 @@ class ProcessableMixin(object):
         self.after_validation = kwargs.pop('after_validation', ())
         super(ProcessableMixin, self).__init__(*args, **kwargs)
 
-    def apply_processors(self, instance, new_value, before=False, after=False):
+    def _get_processor_kwargs(self, proc, kwargs):
+        """ Get values for arguments expected by processor.
+
+        :kwargs: are filtered by checking which :kwargs: keys are
+        defined as arguments of :proc: callable.
+
+        Arguments:
+            :proc: Processor function.
+            :kwargs: Dict containing full set of values that that are
+                desired to be passed to processor.
+        """
+        defined_args = getargspec(proc).args
+        return {k: v for k, v in kwargs.items() if k in defined_args}
+
+    def apply_processors(self, instance, new_value,
+                         before=False, after=False):
         processors = []
         if before:
             processors += list(self.before_validation)
         if after:
             processors += list(self.after_validation)
         for proc in processors:
-            new_value = proc(instance=instance, new_value=new_value)
+            proc_kwargs = self._get_processor_kwargs(proc, kwargs={
+                'instance': instance,
+                'new_value': new_value,
+            })
+            new_value = proc(**proc_kwargs)
         return new_value
 
 

--- a/nefertari_mongodb/tests/test_documents.py
+++ b/nefertari_mongodb/tests/test_documents.py
@@ -91,8 +91,6 @@ class TestBaseMixin(object):
                     'name': {'type': 'string'},
                     'parent': {'type': 'string'},
                     'status': {'type': 'string'},
-                    'updated_at': {'format': 'dateOptionalTime',
-                                   'type': 'date'}
                 }
             }
         }
@@ -105,8 +103,6 @@ class TestBaseMixin(object):
                     'id': {'type': 'string'},
                     'name': {'type': 'string'},
                     'child': {'type': 'object'},
-                    'updated_at': {'format': 'dateOptionalTime',
-                                   'type': 'date'}
                 }
             }
         }
@@ -322,12 +318,10 @@ class TestBaseDocument(object):
             '_version': None,
             'name': None,
             'model2': None,
-            'updated_at': None,
         }
 
         assert MyModel2.get_null_values() == {
             '_version': None,
             'models1': [],
             'name': None,
-            'updated_at': None,
         }

--- a/nefertari_mongodb/tests/test_documents.py
+++ b/nefertari_mongodb/tests/test_documents.py
@@ -325,3 +325,12 @@ class TestBaseDocument(object):
             'models1': [],
             'name': None,
         }
+
+    def test_clean(self):
+        class MyModel1(docs.BaseDocument):
+            name = fields.IdField(onupdate='foo')
+        obj = MyModel1()
+        obj._created = False
+        assert obj.name is None
+        obj.clean()
+        assert obj.name == 'foo'


### PR DESCRIPTION
* Add support for field SQLA-like onupdate argument 
* Remove `updated_at` field definition from BaseDocument
* onupdate value may be regular string, int, etc or callable that returns a value