### PR TITLE
Pass request_params around instead of refresh_index

### DIFF
--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -664,9 +664,10 @@ class BaseDocument(six.with_metaclass(DocumentMetaclass,
             hook(document=self)
 
     def update(self, params, request_params=None, **kw):
+        kw['request_params'] = request_params
         # request_params are passed to _update and then to save
         try:
-            return self._update(params, request_params, **kw)
+            return self._update(params, **kw)
         except (mongo.NotUniqueError, mongo.OperationError) as e:
             if (e.__class__ is mongo.OperationError
                     and 'E11000' not in e.message):

--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -395,7 +395,7 @@ class BaseMixin(object):
         return items_count
 
     @classmethod
-    def _update_many(cls, items, refresh_index=None, **params):
+    def _update_many(cls, items, params, refresh_index=None):
         """ Update objects from :items:
 
         If :items: is an instance of `mongoengine.queryset.queryset.QuerySet`

--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -387,15 +387,15 @@ class BaseMixin(object):
         return self.save(**kw)
 
     @classmethod
-    def _delete_many(cls, items, refresh_index=None):
+    def _delete_many(cls, items, request_params=None):
         """ Delete objects from :items: """
         items_count = len(items)
         for item in items:
-            item.delete(refresh_index=refresh_index)
+            item.delete(request_params)
         return items_count
 
     @classmethod
-    def _update_many(cls, items, params, refresh_index=None):
+    def _update_many(cls, items, params, request_params=None):
         """ Update objects from :items:
 
         If :items: is an instance of `mongoengine.queryset.queryset.QuerySet`
@@ -406,11 +406,11 @@ class BaseMixin(object):
         """
         if isinstance(items, mongo.queryset.queryset.QuerySet):
             items.update(**params)
-            on_bulk_update(cls, items, refresh_index=refresh_index)
+            on_bulk_update(cls, items, request_params)
             return cls.count(items)
         items_count = len(items)
         for item in items:
-            item.update(params, refresh_index=refresh_index)
+            item.update(params, request_params)
         return items_count
 
     def __repr__(self):
@@ -480,7 +480,7 @@ class BaseMixin(object):
 
     def update_iterables(self, params, attr, unique=False,
                          value_type=None, save=True,
-                         refresh_index=None):
+                         request_params=None):
         is_dict = isinstance(type(self)._fields[attr], mongo.DictField)
         is_list = isinstance(type(self)._fields[attr], mongo.ListField)
 
@@ -517,7 +517,7 @@ class BaseMixin(object):
 
             setattr(self, attr, final_value)
             if save:
-                self.save(refresh_index=refresh_index)
+                self.save(request_params)
 
         def update_list(update_params):
             final_value = getattr(self, attr, []) or []
@@ -546,7 +546,7 @@ class BaseMixin(object):
 
             setattr(self, attr, final_value)
             if save:
-                self.save(refresh_index=refresh_index)
+                self.save(request_params)
 
         if is_dict:
             update_dict(params)
@@ -628,7 +628,7 @@ class BaseDocument(six.with_metaclass(DocumentMetaclass,
         if self._is_modified():
             self._version += 1
 
-    def save(self, *arg, **kw):
+    def save(self, request_params=None, *arg, **kw):
         """
         Force insert document in creation so that unique constraits are
         respected.
@@ -636,8 +636,7 @@ class BaseDocument(six.with_metaclass(DocumentMetaclass,
         (as opposed to an 'update' for example).
         """
         kw['force_insert'] = self._created
-
-        self._refresh_index = kw.pop('refresh_index', None)
+        self._request_params = request_params
         self._bump_version()
         try:
             super(BaseDocument, self).save(*arg, **kw)
@@ -664,10 +663,10 @@ class BaseDocument(six.with_metaclass(DocumentMetaclass,
         for hook in self._backref_hooks:
             hook(document=self)
 
-    def update(self, params, **kw):
-        # refresh_index is passed to _update and then to save
+    def update(self, params, request_params=None, **kw):
+        # request_params are passed to _update and then to save
         try:
-            return self._update(params, **kw)
+            return self._update(params, request_params, **kw)
         except (mongo.NotUniqueError, mongo.OperationError) as e:
             if (e.__class__ is mongo.OperationError
                     and 'E11000' not in e.message):
@@ -688,9 +687,9 @@ class BaseDocument(six.with_metaclass(DocumentMetaclass,
                 'Resource `%s`: %s' % (self.__class__.__name__, e),
                 extra={'data': e})
 
-    def delete(self, refresh_index=None, **kwargs):
-        self._refresh_index = refresh_index
-        super(BaseDocument, self).delete(**kwargs)
+    def delete(self, request_params=None, **kw):
+        self._request_params = request_params
+        super(BaseDocument, self).delete(**kw)
 
     def apply_processors(self, field_names=None, before=False, after=False):
         """ Apply processors to fields with :field_names: names.

--- a/nefertari_mongodb/signals.py
+++ b/nefertari_mongodb/signals.py
@@ -10,25 +10,25 @@ log = logging.getLogger(__name__)
 def on_post_save(sender, document, **kw):
     """ Add new document to index or update existing. """
     from nefertari.elasticsearch import ES
-    refresh_index = getattr(document, '_refresh_index', None)
+    request_params = getattr(document, '_request_params', None)
     created = kw.get('created', False)
     if created:
         ES(document.__class__.__name__).index(
-            document.to_dict(), refresh_index=refresh_index)
+            document.to_dict(), request_params=request_params)
     elif not created and document._get_changed_fields():
         document.reload()
         ES(document.__class__.__name__).index(
-            document.to_dict(), refresh_index=refresh_index)
+            document.to_dict(), request_params=request_params)
 
 
 def on_post_delete(sender, document, **kw):
     from nefertari.elasticsearch import ES
-    refresh_index = getattr(document, '_refresh_index', None)
+    request_params = getattr(document, '_request_params', None)
     ES(document.__class__.__name__).delete(
-        document.id, refresh_index=refresh_index)
+        document.id, request_params=request_params)
 
 
-def on_bulk_update(model_cls, objects, refresh_index=None):
+def on_bulk_update(model_cls, objects, request_params):
     if not getattr(model_cls, '_index_enabled', False):
         return
 
@@ -38,11 +38,11 @@ def on_bulk_update(model_cls, objects, refresh_index=None):
     from nefertari.elasticsearch import ES
     es = ES(source=model_cls.__name__)
     documents = to_dicts(objects)
-    es.index(documents, refresh_index=refresh_index)
+    es.index(documents, request_params=request_params)
 
     # Reindex relationships
     for obj in objects:
-        es.index_refs(obj, refresh_index=refresh_index)
+        es.index_refs(obj, request_params=request_params)
 
 
 def setup_es_signals_for(source_cls):


### PR DESCRIPTION
Also changes `_update_many` to receive dict of params to be updated, instead of `**kwargs`