### PR TITLE
Disable DictField indexation

### DIFF
--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -75,7 +75,7 @@ TYPES_MAP = {
 
     BooleanField: {'type': 'boolean'},
     BinaryField: {'type': 'object'},
-    DictField: {'type': 'object'},
+    DictField: {'type': 'object', 'enabled': False},
 
     DecimalField: {'type': 'double'},
     FloatField: {'type': 'double'},


### PR DESCRIPTION
Indexation of DictField is disabled to allow storing arbitrary JSON data in ES.
https://www.elastic.co/guide/en/elasticsearch/reference/1.4/mapping-object-type.html#_enabled_3