### PR TITLE
Nesting and indexation improvements

### DIFF
--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -488,12 +488,12 @@ class BaseMixin(object):
 
         for field_name in relationship_fields:
             value = getattr(self, field_name)
-            if value:
-                if not isinstance(value, list):
-                    value = [value]
-                value_type = value[0].__class__
-                documents = [val.to_dict() for val in value]
-                yield (value_type, documents)
+            if not value:
+                return
+            if not isinstance(value, list):
+                value = [value]
+            value_type = value[0].__class__
+            yield (value_type, value)
 
     def update_iterables(self, params, attr, unique=False,
                          value_type=None, save=True,

--- a/nefertari_mongodb/documents.py
+++ b/nefertari_mongodb/documents.py
@@ -456,10 +456,13 @@ class BaseMixin(object):
         return null_values
 
     def to_dict(self, **kwargs):
+        __depth = kwargs.get('__depth')
+        depth_reached = __depth is not None and __depth <= 0
+
         def _process(key, val):
             is_doc = isinstance(val, mongo.Document)
             include = key in self._nested_relationships
-            if is_doc and not include:
+            if is_doc and (not include or depth_reached):
                 val = getattr(val, val.pk_field(), None)
             return val
 

--- a/nefertari_mongodb/signals.py
+++ b/nefertari_mongodb/signals.py
@@ -18,7 +18,7 @@ def on_post_save(sender, document, **kw):
     elif not created and document._get_changed_fields():
         es = ES(document.__class__.__name__)
         es.index(document.to_dict(), **common_kw)
-        es.index_relations(document, **common_kw)
+        es.index_relations(document, nested_only=True, **common_kw)
 
 
 def on_post_delete(sender, document, **kw):
@@ -42,7 +42,7 @@ def on_bulk_update(model_cls, objects, request):
 
     # Reindex relationships
     for obj in objects:
-        es.index_relations(obj, request=request)
+        es.index_relations(obj, request=request, nested_only=True)
 
 
 def setup_es_signals_for(source_cls):

--- a/nefertari_mongodb/signals.py
+++ b/nefertari_mongodb/signals.py
@@ -18,7 +18,7 @@ def on_post_save(sender, document, **kw):
     elif not created and document._get_changed_fields():
         es = ES(document.__class__.__name__)
         es.index(document.to_dict(), **common_kw)
-        es.index_refs(document, **common_kw)
+        es.index_relations(document, **common_kw)
 
 
 def on_post_delete(sender, document, **kw):
@@ -42,7 +42,7 @@ def on_bulk_update(model_cls, objects, request):
 
     # Reindex relationships
     for obj in objects:
-        es.index_refs(obj, request=request)
+        es.index_relations(obj, request=request)
 
 
 def setup_es_signals_for(source_cls):


### PR DESCRIPTION
* BaseMixin.to_dict now supports `__depth` param which is used to specify nesting depth.
* BaseMixin.get_related_documents also processes fields which hold collections of objects.
* BaseMixin.get_related_documents has new param `nested_only`. When True, return results only contain data for models on which current model and field are nested.
* BaseMixin.get_related_documents second item in yielded results must be list of DB objects and not dicts.